### PR TITLE
Weighted probabilities for spawning items

### DIFF
--- a/Scenes/Game.tscn
+++ b/Scenes/Game.tscn
@@ -67,8 +67,8 @@ bus = "Music"
 tracks = [ ExtResource( 19 ), ExtResource( 18 ), ExtResource( 21 ), ExtResource( 22 ), ExtResource( 20 ) ]
 volumes = {
 ExtResource( 21 ): -6.0,
-ExtResource( 18 ): 0.0,
 ExtResource( 22 ): 0.0,
 ExtResource( 20 ): 0.0,
+ExtResource( 18 ): 0.0,
 ExtResource( 19 ): 6.0
 }

--- a/Scenes/Game.tscn
+++ b/Scenes/Game.tscn
@@ -54,6 +54,7 @@ enemy_speed_increase = 0.01
 enemy_health_increase = 0.012
 enemy_damage_increase = 0.01
 item_array = [ ExtResource( 10 ), ExtResource( 2 ), ExtResource( 11 ), ExtResource( 12 ), ExtResource( 13 ), ExtResource( 14 ), ExtResource( 23 ), ExtResource( 25 ) ]
+item_likelihood = [ 10, 10, 15, 10, 15, 3, 5, 5 ]
 
 [node name="Map" parent="." instance=ExtResource( 3 )]
 position = Vector2( 0, 2.24487 )
@@ -65,9 +66,9 @@ autoplay = false
 bus = "Music"
 tracks = [ ExtResource( 19 ), ExtResource( 18 ), ExtResource( 21 ), ExtResource( 22 ), ExtResource( 20 ) ]
 volumes = {
-ExtResource( 19 ): 6.0,
-ExtResource( 18 ): 0.0,
 ExtResource( 21 ): -6.0,
+ExtResource( 18 ): 0.0,
+ExtResource( 22 ): 0.0,
 ExtResource( 20 ): 0.0,
-ExtResource( 22 ): 0.0
+ExtResource( 19 ): 6.0
 }

--- a/Scripts/Spawner.gd
+++ b/Scripts/Spawner.gd
@@ -46,7 +46,8 @@ export (PackedScene) var default_enemy
 
 #Items
 export (Array,PackedScene) var item_array
-#Weapon
+export (Array, int)var item_likelihood setget changed_likelihood##likelihood for an item to be spawned relative to eachtother.(10 = 2x as likely as 5)
+var item_probs:Array = [] #Gets calculated from item_likelihood. Actual probability.
 
 onready var game = get_node("/root/Game")
 onready var debug_gui =get_node("/root/Game/GUI/HUD/VBoxContainer/DebugLayout")
@@ -134,3 +135,38 @@ func spawn(scene):
 func set_map_size(x_size:float,y_size:float)->void:
 	map_size_x = x_size/2
 	map_size_y = y_size/2
+
+func get_random_item():
+	pass
+
+##Uses the array of likelihoods to create item_probs wich is used to retrieve a random item
+func calc_item_probs():
+	var start:float = 0
+	if len(item_array) != len (item_likelihood):
+		print_debug("ERROR: AMOUNT OF LIKELIHOODS DOES NOT EQUAL AMOUNT OF ITEMS IN SPAWNER")
+		return
+	
+	#if len(item_probs) != len(item_array):
+	#	item_probs.resize(len(item_array))
+	var new_item_probs:Array=[]
+	var total:float = float(sum(item_likelihood))
+	print_debug(total)
+	#var i:int = 0
+	for item_like in item_likelihood:
+		var prob:float =float(item_like)/total
+		print_debug(prob)
+		new_item_probs.append(start + prob)
+		start +=prob
+		#i+=1
+	item_probs = new_item_probs
+	print_debug(item_probs)
+
+func changed_likelihood(new_likelihoods) -> void:
+	item_likelihood = new_likelihoods
+	calc_item_probs()
+
+func sum(int_array:Array)-> int:
+	var res:int = 0
+	for el in int_array:
+		res += el
+	return res

--- a/Scripts/Spawner.gd
+++ b/Scripts/Spawner.gd
@@ -72,7 +72,8 @@ func handle_item_spawning(delta)->void:
 
 ##Spawns a random item at a given global position
 func spawn_rand_item_at(pos)->void:
-	spawn_at(item_array[randi()%len(item_array)],pos)
+	#spawn_at(item_array[randi()%len(item_array)],pos)
+	spawn_at(get_random_item(),pos)
 
 ##Spawns a random item at a given position with a certain propability
 func spawn_rand_item_at_prob(prob,pos)->void:
@@ -137,17 +138,18 @@ func set_map_size(x_size:float,y_size:float)->void:
 	map_size_y = y_size/2
 
 func get_random_item():
-	pass
+	if item_probs == []:
+		calc_item_probs()
+	var _item = item_array[item_probs.bsearch(randf())]
+	return _item
 
 ##Uses the array of likelihoods to create item_probs wich is used to retrieve a random item
-func calc_item_probs():
+func calc_item_probs() -> void:
 	var start:float = 0
 	if len(item_array) != len (item_likelihood):
 		print_debug("ERROR: AMOUNT OF LIKELIHOODS DOES NOT EQUAL AMOUNT OF ITEMS IN SPAWNER")
 		return
 	
-	#if len(item_probs) != len(item_array):
-	#	item_probs.resize(len(item_array))
 	var new_item_probs:Array=[]
 	var total:float = float(sum(item_likelihood))
 	print_debug(total)
@@ -157,9 +159,10 @@ func calc_item_probs():
 		print_debug(prob)
 		new_item_probs.append(start + prob)
 		start +=prob
-		#i+=1
+		
 	item_probs = new_item_probs
 	print_debug(item_probs)
+	#print_debug(item_probs.bsearch(0.95,true))
 
 func changed_likelihood(new_likelihoods) -> void:
 	item_likelihood = new_likelihoods


### PR DESCRIPTION
Now each item on the spawner can get a assigned likelihood, which determens its probability to be spawned when an item is spawned. The values have to be seen as relative to eachother and not to 100. E.g. if item a has 10, item b has 20 and there are no other items, it resolves to p(a)=0.33, p(b)=0.66 . The likelihoods can sum up to more than hundret but the probabilitys will automativly still add up to 100%. Adresses Issue https://github.com/hepfnepf/Blutfest/issues/79.