### PR TITLE
Fixing:Frozen enemys do not get refrozen from item

### DIFF
--- a/Scenes/Game.tscn
+++ b/Scenes/Game.tscn
@@ -67,9 +67,9 @@ autoplay = false
 bus = "Music"
 tracks = [ ExtResource( 19 ), ExtResource( 18 ), ExtResource( 21 ), ExtResource( 22 ), ExtResource( 20 ) ]
 volumes = {
-ExtResource( 22 ): 0.0,
-ExtResource( 20 ): 0.0,
 ExtResource( 18 ): 0.0,
-ExtResource( 21 ): -6.0,
-ExtResource( 19 ): 6.0
+ExtResource( 19 ): 6.0,
+ExtResource( 20 ): 0.0,
+ExtResource( 22 ): 0.0,
+ExtResource( 21 ): -6.0
 }

--- a/Scenes/Items/EffectNodes/EnemyIceEffect.gd
+++ b/Scenes/Items/EffectNodes/EnemyIceEffect.gd
@@ -6,5 +6,5 @@ func add_effect():
 
 func remove_effect():
 	if enemy.has_method("unfreeze"):
-		enemy.unfreeze()
+		enemy.defreeze()
 

--- a/Scripts/Actor.gd
+++ b/Scripts/Actor.gd
@@ -85,6 +85,10 @@ func freeze()->void:
 		#Ai checks in its process funtion if enemy is frozen. It skips process then.
 	freeze_amount+=1
 
+func defreeze()-> void:
+	freeze_amount -= 1
+	if freeze_amount <= 0:
+		unfreeze()
 func unfreeze()-> void:
 	freeze_amount=0
 	$Ice.hide()


### PR DESCRIPTION
Fixed bug in which the ice effect would not stack, because the wrong function was called in the items script.
Adresses Issue https://github.com/hepfnepf/Blutfest/issues/90,