### PR TITLE
Ammo infinity now skips ahead current reloading when collected.

### DIFF
--- a/Scenes/Game.tscn
+++ b/Scenes/Game.tscn
@@ -93,9 +93,9 @@ autoplay = false
 bus = "Music"
 tracks = [ ExtResource( 19 ), ExtResource( 18 ), ExtResource( 21 ), ExtResource( 22 ), ExtResource( 20 ) ]
 volumes = {
-ExtResource( 19 ): 6.0,
 ExtResource( 20 ): 0.0,
-ExtResource( 21 ): -6.0,
+ExtResource( 22 ): 0.0,
 ExtResource( 18 ): 0.0,
-ExtResource( 22 ): 0.0
+ExtResource( 19 ): 6.0,
+ExtResource( 21 ): -6.0
 }

--- a/Scenes/Items/EffectNodes/AmmoInfinity.gd
+++ b/Scenes/Items/EffectNodes/AmmoInfinity.gd
@@ -23,6 +23,10 @@ func add_effect():
 		weapon.fire_rate_delta += fire_rate_delta
 		weapon.set_fire_rate(new_fire_rate)
 
+		#Skip reloading
+		if weapon.is_reloading:
+			weapon.instant_finish_reloading()
+
 func remove_effect():
 	if is_instance_valid(weapon):
 		weapon.ammo_infinity_stack -= 1

--- a/Scenes/Weapons/Weapons/WeaponBasis.gd
+++ b/Scenes/Weapons/Weapons/WeaponBasis.gd
@@ -22,7 +22,7 @@ export (float) var spread_inc = 0.05#per shot
 export (float) var spread_dec = 0.04#per second
 
 #export (bool) var does_explode = false
-export (float) var explosion_damage = 0
+export (float) var explosion_damage = 0.0
 
 export (PackedScene) var Bullet
 
@@ -161,6 +161,15 @@ func reload():
 		tween.start()
 	if reload_time == 0:#skip reloading
 		_on_ReloadTimer_timeout()
+
+func instant_finish_reloading()->void:
+	if is_reloading:
+		reload_timer.stop()
+		tween.stop_all()
+		spread = base_spread
+		_on_ReloadTimer_timeout()
+		emit_signal("reload_percent_change",0)
+
 
 func set_fire_rate(new_fire_rate:float):
 	fire_rate = new_fire_rate


### PR DESCRIPTION
Fixes https://github.com/hepfnepf/Blutfest/issues/177.